### PR TITLE
Fill in None for fields with missing description and units

### DIFF
--- a/lsst_efd_client/__init__.py
+++ b/lsst_efd_client/__init__.py
@@ -1,7 +1,7 @@
 """
 Collection of EFD utilities
 """
-__version__ = "__version__ = '0.7.0'"
+__version__ = "__version__ = '0.8.0'"
 from .auth_helper import NotebookAuth
 from .efd_helper import EfdClient
 from .efd_utils import resample, rendezvous_dataframes, merge_packed_time_series

--- a/lsst_efd_client/efd_helper.py
+++ b/lsst_efd_client/efd_helper.py
@@ -426,14 +426,20 @@ class EfdClient:
         vals = {'name': [], 'description': [], 'units': [], 'aunits': []}
         for f in fields:
             vals['name'].append(f['name'])
-            vals['description'].append(f['description'])
-            vals['units'].append(f['units'])
-            try:
-                if vals['units'][-1] == 'unitless':  # Special case not having units
-                    vals['aunits'].append(u.dimensionless_unscaled)
-                else:
-                    vals['aunits'].append(u.Unit(vals['units'][-1]))
-            except (ValueError, TypeError) as e:
-                logging.warning(f'Could not construct unist: {e.args[0]}')
+            if 'description' in f:
+                vals['description'].append(f['description'])
+            else:
+                vals['description'].append(None)
+            if 'units' in f:
+                vals['units'].append(f['units'])
+                try:
+                    if vals['units'][-1] == 'unitless':  # Special case not having units
+                        vals['aunits'].append(u.dimensionless_unscaled)
+                    else:
+                        vals['aunits'].append(u.Unit(vals['units'][-1]))
+                except (ValueError, TypeError) as e:
+                    logging.warning(f'Could not construct units: {e.args[0]}')
+            else:
+                vals['units'].append(None)
                 vals['aunits'].append(None)
         return pd.DataFrame(vals)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.8.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     tests_require=test_requirements,
     extras_require=extra_requirements,
     url='https://github.com/lsst-sqre/lsst-efd-client',
-    version='0.7.0',
+    version='0.8.0',
     zip_safe=False,
 )


### PR DESCRIPTION
- When retrieving the schema, some fields may not have the
`description` and `units` keys. In this case, check for the keys
first and fill in the returned value with `None` in case they are
missing.