### PR TITLE
Unpin documenteer 0.5 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ test_requirements = ['pytest>=3',
 
 extra_requirements = {
     'dev': [
-        'documenteer[pipelines]'
+        'documenteer[pipelines]',
+        'docutils<0.18'
     ]
 }
 


### PR DESCRIPTION
There seems to be a conflict with the version of documenteer and the pinned dependency on Sphinx and the unpinned sub-dependency on docutils. Using a newer documenteer should resolve this.