### PR TITLE
Pin numpy to version 1.23.5

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -109,3 +109,10 @@ History
   * Consolidate a few tests to make it clearer that they are testing the same thing, and to reduce the number of cassette files needed.
 
 * Run black and isort on the code.
+
+0.13.1 (2023-07-01)
+-------------------
+
+* numpy 1.25.0 breaks compatibility with aioinflux. 
+  Pin numpy to version 1.23.5
+

--- a/lsst_efd_client/__init__.py
+++ b/lsst_efd_client/__init__.py
@@ -1,7 +1,7 @@
 """
 Collection of EFD utilities
 """
-__version__ = "__version__ = '0.13.0'"
+__version__ = "__version__ = '0.13.1'"
 from .auth_helper import NotebookAuth
 from .efd_helper import EfdClient
 from .efd_utils import merge_packed_time_series, rendezvous_dataframes, resample

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0
+current_version = 0.13.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
     tests_require=test_requirements,
     extras_require=extra_requirements,
     url="https://github.com/lsst-sqre/lsst-efd-client",
-    version="0.13.0",
+    version="0.13.1",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "numpy>=1.16.5",
+    "numpy==1.23.5",
     "aioinflux",
     "pandas",
     "astropy",


### PR DESCRIPTION
Latest verstion of numpy breaks compatibility with aioinflux
