### PR TITLE
DM-54440: Drop discovery_v1_path argument to lsst.rsp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "coverage[toml]",
     "httpx",
     "lsst-rsp>=0.10",
+    "pyfakefs",
     "pytest",
     "pytest-asyncio",
     "pytest-vcr",

--- a/src/lsst_efd_client/auth_helper.py
+++ b/src/lsst_efd_client/auth_helper.py
@@ -37,11 +37,6 @@ class NotebookAuth:
         credentials. This need not be provided when running inside a Nublado
         container, where the notebook token will be used, but may be needed
         in other contexts.
-    discovery_v1_path : `pathlib.Path`, optional
-        If provided, override the path to the Repertoire discovery
-        information. This argument is only for testing and should not normally
-        be used. The default behavior uses the normal Nublado path for this
-        information.
 
     Raises
     ------
@@ -54,11 +49,9 @@ class NotebookAuth:
         service_endpoint="https://roundtable.lsst.codes/segwarides/",
         *,
         token: str | None = None,
-        discovery_v1_path: Path | None = None,
     ):
         self.service_endpoint = service_endpoint
         self.token = token
-        self._discovery_v1_path = discovery_v1_path
 
     def get_auth(self, alias):
         """Return the credentials as a tuple
@@ -78,9 +71,7 @@ class NotebookAuth:
         # is the preferred approach inside Nublado notebooks.
         if _HAVE_LSST_RSP:
             try:
-                credentials = get_influxdb_credentials(
-                    alias, self.token, discovery_v1_path=self._discovery_v1_path
-                )
+                credentials = get_influxdb_credentials(alias, self.token)
                 parsed_url = urlparse(credentials.url)
                 return (
                     parsed_url.hostname,

--- a/tests/test_lsst_rsp.py
+++ b/tests/test_lsst_rsp.py
@@ -3,6 +3,7 @@
 import pytest
 
 pytest.importorskip("httpx")
+pytest.importorskip("pyfakefs")
 pytest.importorskip("lsst.rsp")
 pytest.importorskip("respx")
 
@@ -12,13 +13,22 @@ from urllib.parse import urlparse
 
 import respx
 from httpx import Request, Response
+from pyfakefs.fake_filesystem import FakeFilesystem
 
 from lsst_efd_client import NotebookAuth
 
 
-def test_lsst_rsp(respx_mock: respx.Router, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def discovery_path(fs: FakeFilesystem) -> Path:
     data_path = Path(__file__).parent / "data"
     discovery_path = data_path / "discovery" / "v1.json"
+    fs.add_real_directory(data_path)
+    fs.add_real_file(discovery_path, target_path="/etc/nublado/discovery/v1.json")
+    return discovery_path
+
+
+def test_lsst_rsp(respx_mock: respx.Router, monkeypatch: pytest.MonkeyPatch, discovery_path: Path) -> None:
+    data_path = Path(__file__).parent / "data"
     creds_path = data_path / "discovery" / "idfdev_efd.json"
     discovery = json.loads(discovery_path.read_text())
     discovery_data = discovery["influxdb_databases"]["idfdev_efd"]
@@ -42,13 +52,13 @@ def test_lsst_rsp(respx_mock: respx.Router, monkeypatch: pytest.MonkeyPatch) -> 
 
     respx_mock.get(credentials_url).mock(side_effect=handler)
 
-    auth = NotebookAuth(discovery_v1_path=discovery_path)
+    auth = NotebookAuth()
     assert auth.get_auth("idfdev_efd") == expected
 
     # Try again while passing in an explicit token with no environment
     # variable set.
     monkeypatch.delenv("ACCESS_TOKEN")
-    auth = NotebookAuth(token="some-token", discovery_v1_path=discovery_path)
+    auth = NotebookAuth(token="some-token")
     assert auth.get_auth("idfdev_efd") == expected
 
     # If lsst.rsp is available, we shouldn't fall back on Segwarides.


### PR DESCRIPTION
We are removing the testing escape hatch `discovery_v1_path` arugment to lsst.rsp functions for service discovery in favor of using pyfakefs to create a mock file system with discovery files in the expected inside-Nublado locations. Update the lsst-efd-client test suite accordingly.