### PR TITLE
Add output mode to EfdClient

### DIFF
--- a/changelog.d/20260611_134613_29263449+Vebop_OSW_2428.md
+++ b/changelog.d/20260611_134613_29263449+Vebop_OSW_2428.md
@@ -1,0 +1,4 @@
+
+### New features
+
+- Add output_mode to offer json or dataframe based influx output.

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -43,6 +43,7 @@ test:
         - pytest-cov
         - pytest-asyncio
         - respx
+        - aiohttp <3.14.0
     source_files:
         - pyproject.toml
         - src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     # Documentation
     "documenteer[guide]",
     "documenteer[pipelines]",
+    "aiohttp <3.14.0",
 ]
 
 [project.urls]

--- a/src/lsst_efd_client/aioinflux/client.py
+++ b/src/lsst_efd_client/aioinflux/client.py
@@ -126,7 +126,14 @@ class InfluxDBClient:
         :param loop: Asyncio event loop.
         :param kwargs: Additional kwargs for :class:`aiohttp.ClientSession`
         """
-        self._loop = loop or asyncio.get_event_loop()
+        if loop is not None:
+            self._loop = loop
+        else:
+            try:
+                self._loop = asyncio.get_event_loop()
+            except RuntimeError:
+                self._loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self._loop)
         self._session: aiohttp.ClientSession = None
         self._mode = None
         self._output = None

--- a/src/lsst_efd_client/efd_helper.py
+++ b/src/lsst_efd_client/efd_helper.py
@@ -109,6 +109,7 @@ class EfdClientTools:
         creds_service="https://roundtable.lsst.codes/segwarides/",
         timeout=900,
         client=None,
+        output_mode="dataframe",
     ):
         auth = NotebookAuth(service_endpoint=creds_service)
         (
@@ -140,7 +141,7 @@ class EfdClientTools:
                 password=password,
                 db=db_name,
                 mode=mode.value,
-                output="dataframe",
+                output=output_mode,
                 timeout=timeout,
             )
         return schema_registry_url, client
@@ -397,6 +398,11 @@ class EfdClientSync(_EfdClientStatic):
         An instance of a class that ducktypes as
         `aioinflux.client.InfluxDBClient`. The intent is to be able to
         substitute a mocked client for testing.
+    output_mode : `str`, optional
+        The output mode to use for the InfluxDB client. This is passed directly
+        to the `aioinflux.client.InfluxDBClient` constructor. The default is
+        "dataframe" which returns query results as a `~pandas.DataFrame`.
+        "json" also supported.
     """
 
     mode = ClientMode.SYNC
@@ -408,6 +414,7 @@ class EfdClientSync(_EfdClientStatic):
         creds_service="https://roundtable.lsst.codes/segwarides/",
         timeout=900,
         client=None,
+        output_mode="dataframe",
     ):
         (
             self._schema_registry_url,
@@ -419,6 +426,7 @@ class EfdClientSync(_EfdClientStatic):
             creds_service,
             timeout,
             client,
+            output_mode=output_mode,
         )
         self._db_name = db_name
         self._query_history = []
@@ -840,6 +848,11 @@ class EfdClient(_EfdClientStatic):
         An instance of a class that ducktypes as
         `aioinflux.client.InfluxDBClient`. The intent is to be able to
         substitute a mocked client for testing.
+    output_mode : `str`, optional
+        The output mode to use for the InfluxDB client. This is passed directly
+        to the `aioinflux.client.InfluxDBClient` constructor. The default is
+        "dataframe" which returns query results as a `~pandas.DataFrame`.
+        "json" also supported.
     """
 
     mode = ClientMode.ASYNC
@@ -851,11 +864,20 @@ class EfdClient(_EfdClientStatic):
         creds_service="https://roundtable.lsst.codes/segwarides/",
         timeout=900,
         client=None,
+        output_mode=None,
     ):
         (
             self._schema_registry_url,
             self._influx_client,
-        ) = EfdClientTools.get_client(efd_name, EfdClient.mode, db_name, creds_service, timeout, client)
+        ) = EfdClientTools.get_client(
+            efd_name,
+            EfdClient.mode,
+            db_name,
+            creds_service,
+            timeout,
+            client,
+            output_mode=output_mode,
+        )
         self._db_name = db_name
         self._query_history = []
 


### PR DESCRIPTION
To support robot framework, they used to use 'json' output mode when accessing the influx client before the great changes of 2023. This restores that functionality. Completely optional, not noticeable change to anyone who doesn't need this parameter. 